### PR TITLE
Add auto-merge workflow on CodeRabbit approval

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,17 @@
+name: Enable Auto-merge
+
+on:
+  pull_request:
+    types: [opened, reopened]
+
+jobs:
+  enable-auto-merge:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: write
+    steps:
+      - name: Enable auto-merge
+        run: gh pr merge --auto --squash "${{ github.event.pull_request.html_url }}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- PR作成時に自動でauto-mergeモードを有効化するワークフローを追加
- CodeRabbitが承認すると、ブランチ保護の条件を満たしてそのまま自動マージされる

## マージ後にGitHub UIで必要な設定

このPRをマージした後、以下の2箇所をGitHub UIで設定してください（コードでは設定できない）。

### 1. Allow auto-merge を有効化
Settings → General → Pull Requests → **Allow auto-merge** にチェック

### 2. Branch protection rule を設定
Settings → Branches → Add rule
- Branch name pattern: `main`
- **Require a pull request before merging** にチェック
- **Required approving reviews: 1**

🤖 Generated with [Claude Code](https://claude.com/claude-code)