### PR TITLE
Remove English book reviews, keep Japanese only

### DIFF
--- a/books-classics.html
+++ b/books-classics.html
@@ -69,7 +69,6 @@
                             <p class="book-title-ja">プロテスタンティズムの倫理と資本主義の精神</p>
                             <p class="book-author">マックス・ヴェーバー / 大塚 久雄 訳</p>
                             <div class="book-review">
-                                <p class="review-en">What fascinated me most was how capitalism wasn't deliberately designed — it emerged as an unintended consequence of Protestant faith and ethics. The idea that a deeply religious worldview, focused on salvation and calling, quietly gave birth to the rationalized pursuit of profit is both surprising and compelling. It made me reconsider how the systems we take for granted often have origins no one planned for.</p>
                                 <p class="review-ja">最も面白かったのは、資本主義が「作ろうとして作られたのではない」という点。プロテスタントの信仰や倫理観——救済への不安や「天職」の概念——が、意図せずして近代資本主義の精神を育てていったという内容は、なるほどなと思わされた。当たり前のように存在する社会の仕組みが、誰も意図しなかった思想の積み重ねによって形成されているという視点は、世界の見方を少し変えてくれる一冊。</p>
                             </div>
                         </div>
@@ -86,7 +85,6 @@
                             <p class="book-title-ja">ニコマコス倫理学</p>
                             <p class="book-author">アリストテレス / 高田 三郎 訳</p>
                             <div class="book-review">
-                                <p class="review-en">Published in two volumes, this is a challenging read, but the way Aristotle systematically dissects the concept of happiness — what it truly is, and how it relates to virtue and a well-lived life — is genuinely fascinating. What struck me most was the sheer depth of his thinking: the fact that someone in ancient Greece was already grappling with these questions at this level of rigor is nothing short of genius.</p>
                                 <p class="review-ja">上下2冊で構成された非常に難解な本ではあるが、「幸福とは何か」を丁寧に、そして正確に分析していく内容が面白かった。徳や生き方との関係を論理的に積み上げていく姿勢はさすがと感じる。何より驚かされるのは、古代ギリシャの時代にここまで深く人間について考えていたという事実で、アリストテレスの天才性をひしひしと感じる本。</p>
                             </div>
                         </div>

--- a/books-technical.html
+++ b/books-technical.html
@@ -69,7 +69,6 @@
                             <p class="book-title-ja">データエンジニアリングの基礎</p>
                             <p class="book-author">Joe Reis・Matt Housley / 中田 秀基 訳</p>
                             <div class="book-review">
-                                <p class="review-en">A comprehensive guide covering the entire data engineering lifecycle — from data generation to ingestion, transformation, and serving. What stands out is the emphasis on <em>why</em> certain decisions are made, not just the tools themselves.</p>
                                 <p class="review-ja">データエンジニアリングのライフサイクル全体を体系的に解説した一冊。特に「データエンジニアリングの段階的な成熟度」という概念は、現場での業務を振り返る上で非常に参考になった。単なるツールの解説に留まらず、なぜその選択をするのかという視点が随所に散りばめられている点が良い。</p>
                             </div>
                         </div>
@@ -86,7 +85,6 @@
                             <p class="book-title-ja">解読 データアーキテクチャ</p>
                             <p class="book-author">James Serra / 嶋田 健志 監訳</p>
                             <div class="book-review">
-                                <p class="review-en">A clear and practical guide to the major data architecture patterns that have gained traction in recent years — Data Warehouse, Data Fabric, Data Lakehouse, and Data Mesh — with honest comparisons of their trade-offs. What I appreciated most was how it covers concrete technologies and data modeling concepts that <em>Fundamentals of Data Engineering</em> intentionally leaves out. The two books complement each other well, and reading them together gives a much fuller picture of the modern data landscape.</p>
                                 <p class="review-ja">ここ数年のトレンドであるデータウェアハウス・データファブリック・データレイクハウス・データメッシュといったアーキテクチャを、メリット・デメリットを交えながらわかりやすく整理している一冊。特に良かったのは、「データエンジニアリングの基礎」では触れられていなかった具体的な技術やデータモデリングの内容が盛り込まれている点で、両書を合わせて読むことで知識が補完し合う感覚があった。</p>
                             </div>
                         </div>


### PR DESCRIPTION
## Summary

- `books-technical.html` と `books-classics.html` の英語感想（`review-en`）を削除
- 日本語感想（`review-ja`）のみ残す

🤖 Generated with [Claude Code](https://claude.com/claude-code)