### PR TITLE
Remove English descriptions from interview section

### DIFF
--- a/index.html
+++ b/index.html
@@ -262,7 +262,6 @@
                             <p class="interview-title-ja">データ活用を陰で支える立役者！デジタルバンクのデータエンジニア・インタビュー</p>
                             <p class="interview-title-en">The Unsung Hero Behind Data Utilization — A Data Engineer Interview at a Digital Bank</p>
                             <p class="interview-desc-ja">データおよびデータ分析基盤を担当するDWH Groupのインタビュー。データエンジニアの業務内容やチーム体制について紹介しています。</p>
-                            <p class="interview-desc-en">An interview with the DWH Group responsible for data and analytics infrastructure, covering the role of data engineers and team structure.</p>
                             <span class="interview-arrow"><i class="fas fa-arrow-right"></i></span>
                         </div>
                     </a>
@@ -280,7 +279,6 @@
                             <p class="interview-title-ja">【福岡データエンジニアリング勉強会】情報交換もお悩み相談も、リアルで会えばもっと深まる</p>
                             <p class="interview-title-en">[Fukuoka Data Engineering Study Group] Real Meetups Deepen Connections and Problem-Solving</p>
                             <p class="interview-desc-ja">福岡データエンジニアリング勉強会の立ち上げと活動について。"福岡中のデータエンジニアと繋がりたい"という想いから始めたコミュニティを紹介しています。</p>
-                            <p class="interview-desc-en">About the launch and activities of the Fukuoka Data Engineering Study Group — a community born from the desire to connect with every data engineer in Fukuoka.</p>
                             <span class="interview-arrow"><i class="fas fa-arrow-right"></i></span>
                         </div>
                     </a>
@@ -298,7 +296,6 @@
                             <p class="interview-title-ja">課題に向き合い、時代をひらく福岡のエンジニアの力｜EFCアワード2025レポート</p>
                             <p class="interview-title-en">The Power of Fukuoka Engineers Facing Challenges and Opening the Future — EFC Award 2025 Report</p>
                             <p class="interview-desc-ja">第7回EFCアワード表彰式のレポート。コミュニティ部門にて福岡データエンジニアリング勉強会が受賞しました。</p>
-                            <p class="interview-desc-en">A report on the 7th EFC Award ceremony. The Fukuoka Data Engineering Study Group received an award in the Community category.</p>
                             <span class="interview-arrow"><i class="fas fa-arrow-right"></i></span>
                         </div>
                     </a>


### PR DESCRIPTION
## Summary
- インタビューセクション3件の英語説明文（`interview-desc-en`）を削除
- 英語タイトル（`interview-title-en`）は維持

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **変更**
  * インタビューセクションの3つのエントリから英語の説明テキストを削除し、コンテンツを簡潔化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->