### PR TITLE
Add English hobby section

### DIFF
--- a/hobbies.html
+++ b/hobbies.html
@@ -39,6 +39,7 @@
                 <li><a href="#travel">Travel</a></li>
                 <li><a href="#drinks">Drinks</a></li>
                 <li><a href="#exercise">Exercise</a></li>
+                <li><a href="#english">English</a></li>
                 <li><a href="#blog">Blog</a></li>
             </ul>
         </nav>
@@ -173,6 +174,34 @@
                 </div>
             </div>
         </section>
+        <!-- English -->
+        <section id="english">
+            <div class="container">
+                <div class="hobby-header">
+                    <div class="hobby-icon-wrap"><i class="fas fa-language"></i></div>
+                    <div>
+                        <h2>English <span class="hobby-ja">/ 英語</span></h2>
+                        <p class="hobby-sub-en">Studying to travel more freely and read technical docs without friction.</p>
+                        <p class="hobby-sub">海外旅行をより自由に楽しむため、また技術ドキュメントをスムーズに読むために勉強中。</p>
+                    </div>
+                </div>
+                <div class="hobby-cards">
+                    <div class="hobby-item card">
+                        <div class="hobby-item-icon"><i class="fas fa-chart-line"></i></div>
+                        <h3>TOEIC <span class="hobby-item-ja">/ スコア</span></h3>
+                        <p class="hobby-item-en">Practice Test: 665 pts. Aiming higher through consistent daily study.</p>
+                        <p class="hobby-item-ja-p">模擬試験: 665点。毎日の学習を継続してスコアアップを目指しています。</p>
+                    </div>
+                    <div class="hobby-item card">
+                        <div class="hobby-item-icon"><i class="fas fa-certificate"></i></div>
+                        <h3>EIKEN <span class="hobby-item-ja">/ 英検</span></h3>
+                        <p class="hobby-item-en">Preparing for EIKEN Pre-1 (March 2026) as a milestone for overall English proficiency.</p>
+                        <p class="hobby-item-ja-p">総合的な英語力の指標として、英検準1級（2026年3月）の取得を目指して勉強中。</p>
+                    </div>
+                </div>
+            </div>
+        </section>
+
         <!-- Blog -->
         <section id="blog">
             <div class="container">


### PR DESCRIPTION
## Summary
- ホビーページに英語セクションを追加
- ナビゲーションに `English` リンクを追加
- TOEIC（Practice Test 665点）と英検準1級（2026年3月目標）の2カードを掲載

## Test plan
- [ ] hobbies.htmlをブラウザで確認
- [ ] ナビの `English` リンクがセクションへスクロールするか確認
- [ ] 各カードの表示が崩れていないか確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ホビーページに英語学習カテゴリーを追加しました
  * TOEIC と EIKEN 資格情報を含む新しいセクションを実装しました
  * 英語セクションへのナビゲーションリンクを追加しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->